### PR TITLE
fix: prevent comments from being removed, for jsdocs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "checkJs": true,
     "declaration": true,
     "outDir": "./dist",
-    "removeComments": true,
+    "removeComments": false,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

What is the background of this pull request?
- Preserve comment for .d type files
