### PR TITLE
fix: error message handling for W3C documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "test": "npx vitest --run --test-timeout=15000",
+    "test:watch": "npx vitest --test-timeout=15000",
     "test:e2e": "concurrently -k \"npm run e2e:node\" \"npm run wait-and-test\"",
     "e2e:node": "npx hardhat node",
     "wait-and-test": "wait-on tcp:8545 && npm run e2e:test",

--- a/src/__tests__/fixtures/fragments.ts
+++ b/src/__tests__/fixtures/fragments.ts
@@ -1,0 +1,162 @@
+// Verification Responses
+
+export const whenW3CDocumentNotIssued = [
+  {
+    name: 'TransferableRecords',
+    type: 'DOCUMENT_STATUS',
+    data: {
+      details: [
+        {
+          address: '0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3',
+          issued: false,
+          reason: {
+            code: 1,
+            codeString: 'DOCUMENT_NOT_ISSUED',
+            message:
+              'Certificate 0xda7a25d51e62bc50e1c7cfa17f7be0e5df3428b96f584e5d021f0cd8da97306d has not been issued under contract 0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3',
+          },
+        },
+      ],
+      issuedOnAll: false,
+    },
+    reason: {
+      code: 1,
+      codeString: 'DOCUMENT_NOT_ISSUED',
+      message:
+        'Certificate 0xda7a25d51e62bc50e1c7cfa17f7be0e5df3428b96f584e5d021f0cd8da97306d has not been issued under contract 0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3',
+    },
+    status: 'INVALID',
+  },
+  {
+    data: true,
+    status: 'VALID',
+    name: 'W3CSignatureIntegrity',
+    type: 'DOCUMENT_INTEGRITY',
+  },
+  {
+    name: 'W3CIssuerIdentity',
+    type: 'ISSUER_IDENTITY',
+    data: true,
+    status: 'VALID',
+  },
+];
+
+export const whenW3CDocumentHashInvalid = [
+  {
+    data: false,
+    reason: {
+      message: 'Invalid signature.',
+    },
+    status: 'INVALID',
+    name: 'W3CSignatureIntegrity',
+    type: 'DOCUMENT_INTEGRITY',
+  },
+  {
+    name: 'W3CIssuerIdentity',
+    type: 'ISSUER_IDENTITY',
+    data: true,
+    status: 'VALID',
+  },
+  {
+    name: 'TransferableRecords',
+    type: 'DOCUMENT_STATUS',
+    tokenRegistry: '0xFeF3cAF0BA0c184b6b102cE6C32f030Ed647689D',
+    status: 'VALID',
+  },
+];
+
+export const whenW3CDocumentValid = [
+  { type: 'DOCUMENT_INTEGRITY', name: 'W3CSignatureIntegrity', data: true, status: 'VALID' },
+  {
+    name: 'TransferableRecords',
+    type: 'DOCUMENT_STATUS',
+    tokenRegistry: '0xFeF3cAF0BA0c184b6b102cE6C32f030Ed647689D',
+    status: 'VALID',
+  },
+  {
+    name: 'W3CIssuerIdentity',
+    type: 'ISSUER_IDENTITY',
+    data: true,
+    status: 'VALID',
+  },
+];
+
+export const whenW3CDocumentIssuerIdentityInvalid = [
+  {
+    type: 'DOCUMENT_INTEGRITY',
+    name: 'W3CSignatureIntegrity',
+    data: true,
+    status: 'VALID',
+  },
+  {
+    name: 'TransferableRecords',
+    type: 'DOCUMENT_STATUS',
+    tokenRegistry: '0xFeF3cAF0BA0c184b6b102cE6C32f030Ed647689D',
+    status: 'VALID',
+  },
+  {
+    name: 'W3CIssuerIdentity',
+    type: 'ISSUER_IDENTITY',
+    data: true,
+    status: 'INVALID',
+  },
+];
+
+export const whenOADocumentHashInvalid = [
+  {
+    data: false,
+    reason: {
+      code: 0,
+      codeString: 'DOCUMENT_TAMPERED',
+      message: 'Certificate has been tampered with',
+    },
+    status: 'INVALID',
+    name: 'OpenAttestationHash',
+    type: 'DOCUMENT_INTEGRITY',
+  },
+  {
+    name: 'OpenAttestationEthereumDocumentStoreStatus',
+    type: 'DOCUMENT_STATUS',
+    data: {
+      issuedOnAll: true,
+      revokedOnAny: false,
+      details: {
+        issuance: [
+          {
+            issued: true,
+            address: '0xF02F69B0c9F9Fc74110545E20a4A8CE7e0575fb4',
+          },
+        ],
+        revocation: [
+          {
+            revoked: false,
+            address: '0xF02F69B0c9F9Fc74110545E20a4A8CE7e0575fb4',
+          },
+        ],
+      },
+    },
+    status: 'VALID',
+  },
+  {
+    reason: {
+      code: 4,
+      codeString: 'SKIPPED',
+      message: 'Document issuers doesn\'t have "tokenRegistry" property or TOKEN_REGISTRY method',
+    },
+    name: 'OpenAttestationEthereumTokenRegistryMinted',
+    status: 'SKIPPED',
+    type: 'DOCUMENT_STATUS',
+  },
+  {
+    name: 'OpenAttestationDnsTxtIdentityProof',
+    type: 'ISSUER_IDENTITY',
+    data: [
+      {
+        status: 'VALID',
+        location: 'example.tradetrust.io',
+        value: '0xe59877ac86c0310e9ddaeb627f42fdee5f793fbe',
+      },
+    ],
+    status: 'VALID',
+  },
+];

--- a/src/__tests__/utils/fragment/errorMessageHandling.test.ts
+++ b/src/__tests__/utils/fragment/errorMessageHandling.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { CONSTANTS } from '@tradetrust-tt/tradetrust-utils';
+
+import { errorMessageHandling } from 'src/utils/fragment';
+
+// Fixtures
+import {
+  whenW3CDocumentNotIssued,
+  whenW3CDocumentHashInvalid,
+  whenW3CDocumentValid,
+  whenW3CDocumentIssuerIdentityInvalid,
+  whenOADocumentHashInvalid,
+} from 'src/__tests__/fixtures/fragments';
+
+describe('errorMessageHandling with fixtures', () => {
+  it('W3C: returns INVALID when document is not issued (TransferableRecords INVALID)', () => {
+    const res = errorMessageHandling(whenW3CDocumentNotIssued as any);
+    expect(res).toEqual([CONSTANTS.TYPES.INVALID]);
+  });
+
+  it('W3C: returns HASH when hash is invalid (W3CSignatureIntegrity INVALID)', () => {
+    const res = errorMessageHandling(whenW3CDocumentHashInvalid as any);
+    expect(res).toEqual([CONSTANTS.TYPES.HASH]);
+  });
+
+  it('W3C: returns IDENTITY when issuer identity invalid', () => {
+    const res = errorMessageHandling(whenW3CDocumentIssuerIdentityInvalid as any);
+    expect(res).toEqual([CONSTANTS.TYPES.IDENTITY]);
+  });
+
+  it('W3C: returns empty array when all fragments are valid', () => {
+    const res = errorMessageHandling(whenW3CDocumentValid as any);
+    expect(res).toEqual([]);
+  });
+
+  it('OA: returns the OA invalid hash error when the fragment has invalid hash', () => {
+    const res = errorMessageHandling(whenOADocumentHashInvalid as any);
+    expect(res).toEqual([CONSTANTS.TYPES.HASH]);
+  });
+});

--- a/src/utils/fragment/index.ts
+++ b/src/utils/fragment/index.ts
@@ -30,16 +30,28 @@ const w3cCredentialStatusSuspended = (fragments: VerificationFragment[]): boolea
 };
 
 const errorMessageHandling = (fragments: VerificationFragment[]): string[] => {
+  const { hashValid, issuedValid, identityValid } = interpretFragments(fragments);
   const errors = [];
   const isW3cFragments = fragments.some(
     (f) => f.name.startsWith('W3C') || f.name === 'TransferableRecords',
   );
   if (isW3cFragments) {
-    if (w3cCredentialStatusRevoked(fragments)) {
-      errors.push(CONSTANTS.TYPES.REVOKED);
-    }
-    if (w3cCredentialStatusSuspended(fragments)) {
-      errors.push(CONSTANTS.TYPES.SUSPENDED);
+    switch (true) {
+      case w3cCredentialStatusRevoked(fragments):
+        errors.push(CONSTANTS.TYPES.REVOKED);
+        break;
+      case w3cCredentialStatusSuspended(fragments):
+        errors.push(CONSTANTS.TYPES.SUSPENDED);
+        break;
+      case !hashValid:
+        errors.push(CONSTANTS.TYPES.HASH);
+        break;
+      case !identityValid:
+        errors.push(CONSTANTS.TYPES.IDENTITY);
+        break;
+      case !issuedValid:
+        errors.push(CONSTANTS.TYPES.INVALID);
+        break;
     }
 
     return errors;


### PR DESCRIPTION
## Summary

Tampered W3C document not showing proper error messages. Update the error messaging handling.

## Changes

- added handling for invalid hash, identity and issue

## Issues

[What are the related issues or stories?](https://afa-cdi.atlassian.net/browse/TT-985)
