### PR TITLE
fix: update oa v3 function

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TrustVC is a comprehensive wrapper library designed to simplify the signing and 
       - [a) wrapOADocument](#a-wrapoadocument)
       - [b) wrapOADocuments](#b-wrapoadocuments)
     - [2. **Signing**](#2-signing)
-      - [a) OpenAttestation Signing (signOA) v2 v3](#a-openattestation-signing-signoa-v2-v3)
+      - [a) OpenAttestation Signing (signOA) v2](#a-openattestation-signing-signoa-v2)
       - [b) TrustVC W3C Signing (signW3C)](#b-trustvc-w3c-signing-signw3c)
     - [3. **Deriving (Selective Disclosure)**](#3-deriving-selective-disclosure)
     - [4. **Verifying**](#4-verifying)
@@ -44,13 +44,13 @@ npm run test
 
 ### 1. **Wrapping**
 
-> This module provides utility functions for wrapping OpenAttestation documents of version 2 (v2) and version 3 (v3). These functions validate the document version and apply the appropriate wrapping logic using the OpenAttestation library. Note that wrapping is not required for W3C-compliant documents, as they follow a different format and standard.
+> This module provides utility functions for wrapping OpenAttestation documents of version 2 (v2). These functions validate the document version and apply the appropriate wrapping logic using the OpenAttestation library. Note that wrapping is not required for W3C-compliant documents, as they follow a different format and standard.
 
 #### a) wrapOADocument
 
 #### Description
 
-> Wraps a single OpenAttestation document asynchronously, supporting both v2 and v3 documents.
+> Wraps a single OpenAttestation v2 document asynchronously.
 
 #### Parameters
 
@@ -71,7 +71,7 @@ npm run test
 import { wrapOADocument } from '@trustvc/trustvc';
 
 const document = {
-  /* OpenAttestation document (v2 or v3) */
+  /* OpenAttestation v2 document */
 };
 const wrappedDocument = await wrapOADocument(document);
 console.log(wrappedDocument);
@@ -81,7 +81,7 @@ console.log(wrappedDocument);
 
 #### Description
 
-> Wraps multiple OpenAttestation documents asynchronously, supporting both v2 and v3 documents.
+> Wraps multiple OpenAttestation v2 documents asynchronously.
 
 #### Parameters
 
@@ -126,7 +126,7 @@ The signing functionality is split into two methods:
 1. signOA: Designed specifically for signing OpenAttestation documents.
 2. signW3C: Tailored for signing W3C-compliant verifiable credentials.
 
-#### a) OpenAttestation Signing (signOA) [v2](https://github.com/Open-Attestation/open-attestation/tree/master/src/2.0) [v3](https://github.com/Open-Attestation/open-attestation/tree/master/src/3.0)
+#### a) OpenAttestation Signing (signOA) [v2](https://github.com/Open-Attestation/open-attestation/tree/master/src/2.0)
 
 ```ts
 import { wrapOA, signOA } from '@trustvc/trustvc';

--- a/src/__tests__/open-attestation/wrap.test.ts
+++ b/src/__tests__/open-attestation/wrap.test.ts
@@ -9,9 +9,9 @@ import {
 } from '../..';
 import {
   BATCHED_RAW_DOCUMENTS_DID_V2,
-  // BATCHED_RAW_DOCUMENTS_DID_V3, // OA v3 wrapping not supported
+  BATCHED_RAW_DOCUMENTS_DID_V3,
   RAW_DOCUMENT_DID_V2,
-  // RAW_DOCUMENT_DNS_DID_V3, // OA v3 wrapping not supported
+  RAW_DOCUMENT_DNS_DID_V3,
 } from '../fixtures/fixtures';
 
 describe.concurrent('wrap document', () => {
@@ -39,6 +39,14 @@ describe.concurrent('wrap document', () => {
   //   expect(proof).not.toHaveProperty('key');
   //   expect(proof).not.toHaveProperty('signature');
   // });
+
+  it('given a v3 document, should throw deprecation error', async ({ expect }) => {
+    await expect(
+      wrapOADocument(RAW_DOCUMENT_DNS_DID_V3 as any),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: OA v3 is deprecated in TrustVC as of 1 October 2025. Please switch over to W3C VC.]`,
+    );
+  });
 
   it('given a invalid document, should throw', async ({ expect }) => {
     await expect(wrapOADocument({} as any)).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -84,6 +92,24 @@ describe.concurrent('wrap documents', () => {
   //     wrapOADocuments([BATCHED_RAW_DOCUMENTS_DID_V2[0], BATCHED_RAW_DOCUMENTS_DID_V3[0]]),
   //   ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Unsupported documents version]`);
   // });
+
+  it('given an array of v3 documents, should throw deprecation error', async ({ expect }) => {
+    await expect(
+      wrapOADocuments(BATCHED_RAW_DOCUMENTS_DID_V3 as any),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: OA v3 is deprecated in TrustVC as of 1 October 2025. Please switch over to W3C VC.]`,
+    );
+  });
+
+  it('given an array of documents with mixed v2 and v3, should throw deprecation error', async ({
+    expect,
+  }) => {
+    await expect(
+      wrapOADocuments([BATCHED_RAW_DOCUMENTS_DID_V2[0], BATCHED_RAW_DOCUMENTS_DID_V3[0]] as any),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: OA v3 is deprecated in TrustVC as of 1 October 2025. Please switch over to W3C VC.]`,
+    );
+  });
 
   it('given an array of invalid documents, should throw', async ({ expect }) => {
     await expect(

--- a/src/__tests__/open-attestation/wrap.test.ts
+++ b/src/__tests__/open-attestation/wrap.test.ts
@@ -3,15 +3,15 @@ import {
   wrapOADocument,
   wrapOADocuments,
   wrapOADocumentsV2,
-  wrapOADocumentsV3,
+  // wrapOADocumentsV3, // OA v3 wrapping not supported
   wrapOADocumentV2,
-  wrapOADocumentV3,
+  // wrapOADocumentV3, // OA v3 wrapping not supported
 } from '../..';
 import {
   BATCHED_RAW_DOCUMENTS_DID_V2,
-  BATCHED_RAW_DOCUMENTS_DID_V3,
+  // BATCHED_RAW_DOCUMENTS_DID_V3, // OA v3 wrapping not supported
   RAW_DOCUMENT_DID_V2,
-  RAW_DOCUMENT_DNS_DID_V3,
+  // RAW_DOCUMENT_DNS_DID_V3, // OA v3 wrapping not supported
 } from '../fixtures/fixtures';
 
 describe.concurrent('wrap document', () => {
@@ -25,19 +25,20 @@ describe.concurrent('wrap document', () => {
     expect(signature).not.toHaveProperty('signature');
   });
 
-  it('given a valid v3 document, should wrap correctly', async ({ expect }) => {
-    const wrapped = await wrapOADocument(RAW_DOCUMENT_DNS_DID_V3);
-    const { proof } = wrapped;
-    expect(proof.merkleRoot.length).toBe(64);
-    expect(proof.privacy.obfuscated).toEqual([]);
-    expect(proof.proofPurpose).toBe('assertionMethod');
-    expect(proof.proofs).toEqual([]);
-    expect(proof.salts.length).toBeGreaterThan(0);
-    expect(proof.targetHash.length).toBe(64);
-    expect(proof.type).toBe('OpenAttestationMerkleProofSignature2018');
-    expect(proof).not.toHaveProperty('key');
-    expect(proof).not.toHaveProperty('signature');
-  });
+  // OA v3 wrapping not supported
+  // it('given a valid v3 document, should wrap correctly', async ({ expect }) => {
+  //   const wrapped = await wrapOADocument(RAW_DOCUMENT_DNS_DID_V3);
+  //   const { proof } = wrapped;
+  //   expect(proof.merkleRoot.length).toBe(64);
+  //   expect(proof.privacy.obfuscated).toEqual([]);
+  //   expect(proof.proofPurpose).toBe('assertionMethod');
+  //   expect(proof.proofs).toEqual([]);
+  //   expect(proof.salts.length).toBeGreaterThan(0);
+  //   expect(proof.targetHash.length).toBe(64);
+  //   expect(proof.type).toBe('OpenAttestationMerkleProofSignature2018');
+  //   expect(proof).not.toHaveProperty('key');
+  //   expect(proof).not.toHaveProperty('signature');
+  // });
 
   it('given a invalid document, should throw', async ({ expect }) => {
     await expect(wrapOADocument({} as any)).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -59,28 +60,30 @@ describe.concurrent('wrap documents', () => {
     }
   });
 
-  it('given an array of valid v3 documents, should wrap correctly', async ({ expect }) => {
-    const wrapped = await wrapOADocuments(BATCHED_RAW_DOCUMENTS_DID_V3);
-    expect(wrapped.length).toBe(2);
-    for (const { proof } of wrapped) {
-      expect(proof.type).toBe('OpenAttestationMerkleProofSignature2018');
-      expect(proof.proofPurpose).toBe('assertionMethod');
-      expect(proof.merkleRoot.length).toBe(64);
-      expect(proof.targetHash.length).toBe(64);
-      expect(proof.salts.length).toBeGreaterThan(0);
-      expect(proof.proofs).not.toEqual([]);
-      expect(proof.proofs?.[0]?.length).toBeGreaterThan(0);
-      expect(proof.privacy.obfuscated).toEqual([]);
-      expect(proof).not.toHaveProperty('key');
-      expect(proof).not.toHaveProperty('signature');
-    }
-  });
+  // OA v3 wrapping not supported
+  // it('given an array of valid v3 documents, should wrap correctly', async ({ expect }) => {
+  //   const wrapped = await wrapOADocuments(BATCHED_RAW_DOCUMENTS_DID_V3);
+  //   expect(wrapped.length).toBe(2);
+  //   for (const { proof } of wrapped) {
+  //     expect(proof.type).toBe('OpenAttestationMerkleProofSignature2018');
+  //     expect(proof.proofPurpose).toBe('assertionMethod');
+  //     expect(proof.merkleRoot.length).toBe(64);
+  //     expect(proof.targetHash.length).toBe(64);
+  //     expect(proof.salts.length).toBeGreaterThan(0);
+  //     expect(proof.proofs).not.toEqual([]);
+  //     expect(proof.proofs?.[0]?.length).toBeGreaterThan(0);
+  //     expect(proof.privacy.obfuscated).toEqual([]);
+  //     expect(proof).not.toHaveProperty('key');
+  //     expect(proof).not.toHaveProperty('signature');
+  //   }
+  // });
 
-  it('given an array of documents with different versions, should throw', async ({ expect }) => {
-    await expect(
-      wrapOADocuments([BATCHED_RAW_DOCUMENTS_DID_V2[0], BATCHED_RAW_DOCUMENTS_DID_V3[0]]),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Unsupported documents version]`);
-  });
+  // OA v3 wrapping not supported
+  // it('given an array of documents with different versions, should throw', async ({ expect }) => {
+  //   await expect(
+  //     wrapOADocuments([BATCHED_RAW_DOCUMENTS_DID_V2[0], BATCHED_RAW_DOCUMENTS_DID_V3[0]]),
+  //   ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Unsupported documents version]`);
+  // });
 
   it('given an array of invalid documents, should throw', async ({ expect }) => {
     await expect(
@@ -89,96 +92,98 @@ describe.concurrent('wrap documents', () => {
   });
 });
 
-describe.concurrent('v3.0 wrap document', () => {
-  it('given a valid v3 document, should wrap correctly', async ({ expect }) => {
-    const wrapped = await wrapOADocumentV3(RAW_DOCUMENT_DNS_DID_V3);
-    const { proof } = wrapped;
-    expect(proof.merkleRoot.length).toBe(64);
-    expect(proof.privacy.obfuscated).toEqual([]);
-    expect(proof.proofPurpose).toBe('assertionMethod');
-    expect(proof.proofs).toEqual([]);
-    expect(proof.salts.length).toBeGreaterThan(0);
-    expect(proof.targetHash.length).toBe(64);
-    expect(proof.type).toBe('OpenAttestationMerkleProofSignature2018');
-    expect(proof).not.toHaveProperty('key');
-    expect(proof).not.toHaveProperty('signature');
-  });
+// OA v3 wrapping not supported
+// describe.concurrent('v3.0 wrap document', () => {
+//   it('given a valid v3 document, should wrap correctly', async ({ expect }) => {
+//     const wrapped = await wrapOADocumentV3(RAW_DOCUMENT_DNS_DID_V3);
+//     const { proof } = wrapped;
+//     expect(proof.merkleRoot.length).toBe(64);
+//     expect(proof.privacy.obfuscated).toEqual([]);
+//     expect(proof.proofPurpose).toBe('assertionMethod');
+//     expect(proof.proofs).toEqual([]);
+//     expect(proof.salts.length).toBeGreaterThan(0);
+//     expect(proof.targetHash.length).toBe(64);
+//     expect(proof.type).toBe('OpenAttestationMerkleProofSignature2018');
+//     expect(proof).not.toHaveProperty('key');
+//     expect(proof).not.toHaveProperty('signature');
+//   });
+//
+//   it('given a document with explicit v3 contexts, but does not conform to the v3 document schema, should throw', async ({
+//     expect,
+//   }) => {
+//     await expect(
+//       wrapOADocumentV3({
+//         version: 'https://schema.openattestation.com/3.0/schema.json',
+//         '@context': [
+//           'https://www.w3.org/2018/credentials/v1',
+//           'https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json',
+//         ],
+//       } as any),
+//     ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Invalid document]`);
+//   });
+//
+//   it('given a valid v3 document but has an extra field, should throw', async ({ expect }) => {
+//     await expect(
+//       wrapOADocumentV3({
+//         ...RAW_DOCUMENT_DNS_DID_V3,
+//         UNKNOWN: 'any',
+//       }),
+//     ).rejects.toThrowErrorMatchingInlineSnapshot(
+//       `[Error: "The property UNKNOWN in the input was not defined in the context"]`,
+//     );
+//   });
+// });
 
-  it('given a document with explicit v3 contexts, but does not conform to the v3 document schema, should throw', async ({
-    expect,
-  }) => {
-    await expect(
-      wrapOADocumentV3({
-        version: 'https://schema.openattestation.com/3.0/schema.json',
-        '@context': [
-          'https://www.w3.org/2018/credentials/v1',
-          'https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json',
-        ],
-      } as any),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Invalid document]`);
-  });
-
-  it('given a valid v3 document but has an extra field, should throw', async ({ expect }) => {
-    await expect(
-      wrapOADocumentV3({
-        ...RAW_DOCUMENT_DNS_DID_V3,
-        UNKNOWN: 'any',
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: "The property UNKNOWN in the input was not defined in the context"]`,
-    );
-  });
-});
-
-describe.concurrent('v3.0 wrap documents', () => {
-  it('given an array of valid v3 documents, should wrap correctly', async ({ expect }) => {
-    const wrapped = await wrapOADocumentsV3(BATCHED_RAW_DOCUMENTS_DID_V3);
-    expect(wrapped.length).toBe(2);
-    for (const { proof } of wrapped) {
-      expect(proof.type).toBe('OpenAttestationMerkleProofSignature2018');
-      expect(proof.proofPurpose).toBe('assertionMethod');
-      expect(proof.merkleRoot.length).toBe(64);
-      expect(proof.targetHash.length).toBe(64);
-      expect(proof.salts.length).toBeGreaterThan(0);
-      expect(proof.proofs).not.toEqual([]);
-      expect(proof.proofs?.[0]?.length).toBeGreaterThan(0);
-      expect(proof.privacy.obfuscated).toEqual([]);
-      expect(proof).not.toHaveProperty('key');
-      expect(proof).not.toHaveProperty('signature');
-    }
-  });
-
-  it('given an array of documents with explicit v3 contexts, but one of them does not conform to the v3 document schema, should throw', async ({
-    expect,
-  }) => {
-    await expect(
-      wrapOADocumentsV3([
-        {
-          version: 'https://schema.openattestation.com/3.0/schema.json',
-          '@context': [
-            'https://www.w3.org/2018/credentials/v1',
-            'https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json',
-          ],
-        },
-        BATCHED_RAW_DOCUMENTS_DID_V3[1],
-      ] as any),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Invalid document]`);
-  });
-
-  it('given an array of valid v3 documents but one of them has an extra field, should throw', async ({
-    expect,
-  }) => {
-    await expect(
-      wrapOADocumentV3([
-        BATCHED_RAW_DOCUMENTS_DID_V3[0],
-        {
-          ...BATCHED_RAW_DOCUMENTS_DID_V3[1],
-          UNKNOWN: 'any',
-        },
-      ] as any),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Invalid document]`);
-  });
-});
+// OA v3 wrapping not supported
+// describe.concurrent('v3.0 wrap documents', () => {
+//   it('given an array of valid v3 documents, should wrap correctly', async ({ expect }) => {
+//     const wrapped = await wrapOADocumentsV3(BATCHED_RAW_DOCUMENTS_DID_V3);
+//     expect(wrapped.length).toBe(2);
+//     for (const { proof } of wrapped) {
+//       expect(proof.type).toBe('OpenAttestationMerkleProofSignature2018');
+//       expect(proof.proofPurpose).toBe('assertionMethod');
+//       expect(proof.merkleRoot.length).toBe(64);
+//       expect(proof.targetHash.length).toBe(64);
+//       expect(proof.salts.length).toBeGreaterThan(0);
+//       expect(proof.proofs).not.toEqual([]);
+//       expect(proof.proofs?.[0]?.length).toBeGreaterThan(0);
+//       expect(proof.privacy.obfuscated).toEqual([]);
+//       expect(proof).not.toHaveProperty('key');
+//       expect(proof).not.toHaveProperty('signature');
+//     }
+//   });
+//
+//   it('given an array of documents with explicit v3 contexts, but one of them does not conform to the v3 document schema, should throw', async ({
+//     expect,
+//   }) => {
+//     await expect(
+//       wrapOADocumentsV3([
+//         {
+//           version: 'https://schema.openattestation.com/3.0/schema.json',
+//           '@context': [
+//             'https://www.w3.org/2018/credentials/v1',
+//             'https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json',
+//           ],
+//         },
+//         BATCHED_RAW_DOCUMENTS_DID_V3[1],
+//       ] as any),
+//     ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Invalid document]`);
+//   });
+//
+//   it('given an array of valid v3 documents but one of them has an extra field, should throw', async ({
+//     expect,
+//   }) => {
+//     await expect(
+//       wrapOADocumentV3([
+//         BATCHED_RAW_DOCUMENTS_DID_V3[0],
+//         {
+//           ...BATCHED_RAW_DOCUMENTS_DID_V3[1],
+//           UNKNOWN: 'any',
+//         },
+//       ] as any),
+//     ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Invalid document]`);
+//   });
+// });
 
 describe.concurrent('v2.0 wrap document', () => {
   it('given a valid v2 document, should wrap correctly', async ({ expect }) => {

--- a/src/open-attestation/wrap.ts
+++ b/src/open-attestation/wrap.ts
@@ -56,6 +56,10 @@ async function wrapOADocument<T extends OpenAttestationDocument>(
 ): Promise<WrappedDocument<T>> {
   if (utils.isRawV2Document(document)) {
     return wrapOADocumentV2(document) as Promise<WrappedDocument<T>>;
+  } else if (utils.isRawV3Document(document)) {
+    throw new Error(
+      'OA v3 is deprecated in TrustVC as of 1 October 2025. Please switch over to W3C VC.',
+    );
   } else {
     throw new Error('Unsupported document version');
   }
@@ -75,6 +79,10 @@ async function wrapOADocuments<T extends OpenAttestationDocument>(
 ): Promise<WrappedDocument<T>[]> {
   if (documents.every((s) => utils.isRawV2Document(s))) {
     return wrapOADocumentsV2(documents) as Promise<WrappedDocument<T>[]>;
+  } else if (documents.some((s) => utils.isRawV3Document(s))) {
+    throw new Error(
+      'OA v3 is deprecated in TrustVC as of 1 October 2025. Please switch over to W3C VC.',
+    );
   } else {
     throw new Error('Unsupported documents version');
   }

--- a/src/open-attestation/wrap.ts
+++ b/src/open-attestation/wrap.ts
@@ -4,8 +4,8 @@ import {
   v2,
   wrapDocument as wrapOADocument_v2,
   wrapDocuments as wrapOADocuments_v2,
-  __unsafe__use__it__at__your__own__risks__wrapDocuments as wrapOADocumentsV3,
-  __unsafe__use__it__at__your__own__risks__wrapDocument as wrapOADocumentV3,
+  // __unsafe__use__it__at__your__own__risks__wrapDocuments as wrapOADocumentsV3,
+  // __unsafe__use__it__at__your__own__risks__wrapDocument as wrapOADocumentV3,
   WrappedDocument,
 } from '@tradetrust-tt/tradetrust';
 
@@ -43,54 +43,41 @@ const wrapOADocumentsV2 = async <T extends v2.OpenAttestationDocument>(
 };
 
 /**
- * Asynchronously wraps a v2 / v3 OpenAttestation document.
+ * Asynchronously wraps a V2 OpenAttestation document.
  *
  * This function takes an OpenAttestation document and validates its version before wrapping it
- * using the OpenAttestation library's `wrapOADocument` function. The function will throw any errors
- * encountered during the wrapping process, as handled by the OpenAttestation library.
+ * using the OpenAttestation library's `wrapOADocument` function. Only V2 documents are supported.
  * @param {OpenAttestationDocument} document - The OpenAttestation document to be wrapped.
  * @returns {Promise<WrappedDocument>} - A promise that resolves to the wrapped document.
- * @throws {Error} - Any errors thrown by the `wrapOADocument` function will propagate naturally.
+ * @throws {Error} - Throws if the document is not a V2 document.
  */
 async function wrapOADocument<T extends OpenAttestationDocument>(
   document: T,
 ): Promise<WrappedDocument<T>> {
   if (utils.isRawV2Document(document)) {
     return wrapOADocumentV2(document) as Promise<WrappedDocument<T>>;
-  } else if (utils.isRawV3Document(document)) {
-    return wrapOADocumentV3(document) as Promise<WrappedDocument<T>>;
   } else {
     throw new Error('Unsupported document version');
   }
 }
 
 /**
- * Asynchronously wraps multiple v2 / v3 OpenAttestation documents.
+ * Asynchronously wraps multiple V2 OpenAttestation documents.
  *
  * This function takes an array of OpenAttestation documents and validates their versions before wrapping them
- * using the OpenAttestation library's `wrapOADocuments` function. The function will throw any errors
- * encountered during the wrapping process, as handled by the OpenAttestation library.
+ * using the OpenAttestation library's `wrapOADocuments` function. Only V2 documents are supported.
  * @param {OpenAttestationDocument[]} documents - The OpenAttestation documents to be wrapped.
  * @returns {Promise<WrappedDocument[]>} - A promise that resolves to the wrapped documents.
- * @throws {Error} - Any errors thrown by the `wrapOADocuments` function will propagate naturally.
+ * @throws {Error} - Throws if any document is not a V2 document.
  */
 async function wrapOADocuments<T extends OpenAttestationDocument>(
   documents: T[],
 ): Promise<WrappedDocument<T>[]> {
   if (documents.every((s) => utils.isRawV2Document(s))) {
     return wrapOADocumentsV2(documents) as Promise<WrappedDocument<T>[]>;
-  } else if (documents.every((s) => utils.isRawV3Document(s))) {
-    return wrapOADocumentsV3(documents) as Promise<WrappedDocument<T>[]>;
   } else {
     throw new Error('Unsupported documents version');
   }
 }
 
-export {
-  wrapOADocument,
-  wrapOADocuments,
-  wrapOADocumentsV2,
-  wrapOADocumentsV3,
-  wrapOADocumentV2,
-  wrapOADocumentV3,
-};
+export { wrapOADocument, wrapOADocuments, wrapOADocumentsV2, wrapOADocumentV2 };


### PR DESCRIPTION
## Remove support for OA v3 document issuance

- **`src/open-attestation/wrap.ts`** — Removed v3 wrapping support; updated JSDoc on `wrapOADocument` and `wrapOADocuments` to reflect v2-only behaviour
- **`src/__tests__/open-attestation/wrap.test.ts`** — Commented out all OA v3 wrap test cases and their fixtures/imports (`wrapOADocumentV3`, `wrapOADocumentsV3`, `RAW_DOCUMENT_DNS_DID_V3`, `BATCHED_RAW_DOCUMENTS_DID_V3`)
- **`README.md`** — Removed all OA v3 references from wrapping and signing documentation

> OA v3 document **verification** remains fully supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for OpenAttestation v3 document wrapping. Only v2 documents are now supported; v3 documents will throw a deprecation error.

* **Documentation**
  * Updated wrapping guidance to reference OpenAttestation v2 only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrustVC/trustvc/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->